### PR TITLE
Bug fix for the topical progression visualization

### DIFF
--- a/ontopic/dslib/models/document.py
+++ b/ontopic/dslib/models/document.py
@@ -2033,8 +2033,9 @@ class DSDocument:
                                     x[LEMMA] for x in temp_para["new_accum_lemmas"]
                                 ]:
                                     temp_para["new_accum_lemmas"].append(
-                                        gl
-                                    )  # add 'gl' to the list
+                                        cl
+                                    )  # add 'cl' to the list
+                                    break
 
                 # remove the duplicates. It may be a bit faster to do it here than checking duplicates in the loop above...
                 para["given_accum_lemmas"] = list(set(para["given_accum_lemmas"]))

--- a/ontopic/dslib/models/document.py
+++ b/ontopic/dslib/models/document.py
@@ -2016,6 +2016,7 @@ class DSDocument:
                             )  # add 'gl' to the list
                             break  # 2024.12.02
 
+                    is_done = False
                     for temp_elem in self.elements:
                         temp_para = temp_elem.data
                         if temp_para == para:
@@ -2035,7 +2036,10 @@ class DSDocument:
                                     temp_para["new_accum_lemmas"].append(
                                         cl
                                     )  # add 'cl' to the list
-                                    break
+                                    is_done = True
+                                    break # no need to check other paragraphs
+                    if is_done:
+                        break
 
                 # remove the duplicates. It may be a bit faster to do it here than checking duplicates in the loop above...
                 para["given_accum_lemmas"] = list(set(para["given_accum_lemmas"]))

--- a/ontopic/dslib/models/document.py
+++ b/ontopic/dslib/models/document.py
@@ -2038,8 +2038,8 @@ class DSDocument:
                                     )  # add 'cl' to the list
                                     is_done = True
                                     break # no need to check other paragraphs
-                    if is_done:
-                        break
+                        if is_done:
+                            break
 
                 # remove the duplicates. It may be a bit faster to do it here than checking duplicates in the loop above...
                 para["given_accum_lemmas"] = list(set(para["given_accum_lemmas"]))


### PR DESCRIPTION
The order of topics in the topical progression visualization was sometimes incorrect. The problem was caused by findGivenWordsPara() which was generating the given-new lemmas data incorrectly (in some conditions). This caused getGlobalTopicalProgData to sort topics incorrectly.

The fix was verified with the desktop prototype.